### PR TITLE
Remove direct messaging abilities for guests

### DIFF
--- a/components/legacy_sidebar/channel_create.jsx
+++ b/components/legacy_sidebar/channel_create.jsx
@@ -17,6 +17,7 @@ export default class ChannelCreate extends React.PureComponent {
         createPrivateChannel: PropTypes.func.isRequired,
         createDirectMessage: PropTypes.func.isRequired,
         createPublicDirectChannel: PropTypes.func.isRequired,
+        canSendDirectMessage: PropTypes.bool.isRequired,
         canCreatePublicChannel: PropTypes.bool.isRequired,
         canCreatePrivateChannel: PropTypes.bool.isRequired,
     };
@@ -92,6 +93,10 @@ export default class ChannelCreate extends React.PureComponent {
     };
 
     renderDirect = () => {
+        if (!this.props.canSendDirectMessage) {
+            return null;
+        }
+
         const ariaLabelDM = Utils.localizeMessage('sidebar.createDirectMessage', 'Write a direct message').toLowerCase();
         const tooltip = (
             <Tooltip

--- a/components/legacy_sidebar/channel_more.jsx
+++ b/components/legacy_sidebar/channel_more.jsx
@@ -10,6 +10,8 @@ import {Permissions} from 'matterfoss-redux/constants';
 import TeamPermissionGate from 'components/permissions_gates/team_permission_gate';
 import {intlShape} from 'utils/react_intl';
 
+import {isCurrentUserGuest} from "../../utils/utils";
+
 class ChannelMore extends React.PureComponent {
     static propTypes = {
         currentTeamId: PropTypes.string.isRequired,
@@ -92,7 +94,7 @@ class ChannelMore extends React.PureComponent {
             return null;
         case 'direct':
             return (
-                <li
+                !isCurrentUserGuest() && <li
                     key='dm-more'
                     id='moreDMButton'
                 >

--- a/components/legacy_sidebar/sidebar.jsx
+++ b/components/legacy_sidebar/sidebar.jsx
@@ -137,6 +137,11 @@ class LegacySidebar extends React.PureComponent {
         canCreatePrivateChannel: PropTypes.bool.isRequired,
 
         /**
+         * Permission to send direct messages
+         */
+        canSendDirectMessages: PropTypes.bool,
+
+        /**
          * Flag to display the Switch channel shortcut
          */
         channelSwitcherOption: PropTypes.bool.isRequired,
@@ -155,6 +160,7 @@ class LegacySidebar extends React.PureComponent {
 
     static defaultProps = {
         currentChannel: {},
+        canSendDirectMessages: !Utils.isCurrentUserGuest(),
     }
 
     constructor(props) {
@@ -588,6 +594,7 @@ class LegacySidebar extends React.PureComponent {
                                         sectionType={section.type}
                                         canCreatePublicChannel={this.props.canCreatePublicChannel}
                                         canCreatePrivateChannel={this.props.canCreatePrivateChannel}
+                                        canSendDirectMessage={this.props.canSendDirectMessages}
                                         createPublicChannel={this.showNewPublicChannelModal}
                                         createPrivateChannel={this.showNewPrivateChannelModal}
                                         createDirectMessage={this.handleOpenMoreDirectChannelsModal}

--- a/components/profile_popover/profile_popover.jsx
+++ b/components/profile_popover/profile_popover.jsx
@@ -30,6 +30,7 @@ import CustomStatusModal from 'components/custom_status/custom_status_modal';
 import CustomStatusText from 'components/custom_status/custom_status_text';
 
 import './profile_popover.scss';
+import {isCurrentUserGuest} from "utils/utils.jsx";
 
 /**
  * The profile popover, or hovercard, that appears with user information when clicking
@@ -548,7 +549,7 @@ class ProfilePopover extends React.PureComponent {
             );
         }
 
-        if (this.props.user.id !== this.props.currentUserId && !haveOverrideProp) {
+        if (this.props.user.id !== this.props.currentUserId && !haveOverrideProp && !Utils.isCurrentUserGuest()) {
             dataContent.push(
                 <div
                     data-toggle='tooltip'

--- a/components/sidebar/sidebar_category/sidebar_category.tsx
+++ b/components/sidebar/sidebar_category/sidebar_category.tsx
@@ -19,7 +19,7 @@ import {DraggingState} from 'types/store';
 
 import Constants, {A11yCustomEventTypes, DraggingStateTypes, DraggingStates} from 'utils/constants';
 import {t} from 'utils/i18n';
-import {isKeyPressed} from 'utils/utils';
+import {isKeyPressed, isCurrentUserGuest} from 'utils/utils';
 
 import SidebarChannel from '../sidebar_channel';
 import {SidebarCategoryHeader} from '../sidebar_category_header';
@@ -293,19 +293,20 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
                         isMenuOpen={this.state.isMenuOpen}
                         onToggleMenu={this.handleMenuToggle}
                     />
-                    <OverlayTrigger
-                        delayShow={500}
-                        placement='top'
-                        overlay={addTooltip}
-                    >
-                        <button
-                            className='SidebarChannelGroupHeader_addButton'
-                            onClick={this.handleOpenDirectMessagesModal}
-                            aria-label={addHelpLabel}
+                    {!isCurrentUserGuest() &&
+                        (<OverlayTrigger
+                            delayShow={500}
+                            placement='top'
+                            overlay={addTooltip}
                         >
-                            <i className='icon-plus'/>
-                        </button>
-                    </OverlayTrigger>
+                            <button
+                                className='SidebarChannelGroupHeader_addButton'
+                                onClick={this.handleOpenDirectMessagesModal}
+                                aria-label={addHelpLabel}
+                            >
+                                <i className='icon-plus'/>
+                            </button>
+                        </OverlayTrigger>)}
                 </React.Fragment>
             );
 

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -184,6 +184,13 @@ export function isGuest(user) {
     return false;
 }
 
+export function isCurrentUserGuest() {
+    const getState = store.getState;
+    const currentUser = getCurrentUser(getState());
+
+    return isGuest(currentUser);
+}
+
 export function getTeamRelativeUrl(team) {
     if (!team) {
         return '';


### PR DESCRIPTION
# Description

Guests are not allowed to send direct messages to other members via profile popover

![guests-can-not-send-direct-message-via-profile-popover](https://user-images.githubusercontent.com/1053622/125778284-0526a145-33d3-4458-ae4f-c397a61b94a8.png)

Guests do not see new private message in sidebar

![guests-do-not-see-new-private-message-in-sidebar](https://user-images.githubusercontent.com/1053622/125778309-82405b53-7f39-42a6-a4a7-8c82732ec6cb.png)

Guests can not see button having More label for direct messages in legacy sidebar

![guests-can-not-see-more-button-for-direct-messages-in-legacy-sidebar](https://user-images.githubusercontent.com/1053622/125778266-b0a13022-ec62-4bd8-8a60-4c9fcd5782bc.png)

Admins and regular members can still send direct messages 

![admins-and-members-can-still-send-direct-messages](https://user-images.githubusercontent.com/1053622/125778417-8361f8e8-f5c4-4a03-ac14-f7cb88d85c28.png)

## Requirements

[Access to get users and search users endpoints is forbidden to guests](https://github.com/thierrymarianne/contrib-matterfoss/pull/2)